### PR TITLE
Refine CI

### DIFF
--- a/.github/workflows/create-binder-badge.yaml
+++ b/.github/workflows/create-binder-badge.yaml
@@ -1,8 +1,12 @@
 name: Create Binder Badge
 
 on:
-  pull_request_target:
-    types: [opened]
+  pull_request:
+    types:
+      - opened
+    paths:
+      - "**.ipynb"
+      - "**.csv"
 
 jobs:
   binder-badge:


### PR DESCRIPTION
Only run binder badge job when PR affects CSV or ipynb files