### PR TITLE
Fix issues with running get-data.py in CI

### DIFF
--- a/.github/workflows/update-activity.yaml
+++ b/.github/workflows/update-activity.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: Run script to fetch data
         run: |
           python get-data.py
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       - name: Add and Commit updated CSV file
         uses: EndBug/add-and-commit@v7.4.0
         with:

--- a/.github/workflows/update-activity.yaml
+++ b/.github/workflows/update-activity.yaml
@@ -9,22 +9,27 @@ on:
 jobs:
   update-github-activity:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.5
+
       - name: Install Python
         uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.9
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r dev-requirements.txt
+
       - name: Run script to fetch data
         run: |
           python get-data.py
         env:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
       - name: Add and Commit updated CSV file
         uses: EndBug/add-and-commit@v7.4.0
         with:

--- a/get-data.py
+++ b/get-data.py
@@ -3,7 +3,6 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import fastcore
 import pandas as pd
-from ghapi.all import github_token
 from ghapi.core import GhApi
 from ghapi.page import paged
 
@@ -60,7 +59,7 @@ def process_gh_results(page):
 
 
 n_proc = os.cpu_count()
-token = os.environ["ACCESS_TOKEN"] if "ACCESS_TOKEN" in os.environ else github_token()
+token = os.environ["ACCESS_TOKEN"] if "ACCESS_TOKEN" in os.environ else None
 
 if token is None:
     raise ValueError("ACCESS_TOKEN must be set!")


### PR DESCRIPTION
- `GITHUB_TOKEN` doesn't have the right permissions. Needs to be a PAT so script can act "as me"
- Remove `github_token` from `get-data.py`
- Add `ACCESS_TOKEN` as environment variable in Update GitHub Activity workflow file
  - Needs to be added to repo as a secret