### PR TITLE
Wrap concurrency executor in try/except block

### DIFF
--- a/.github/workflows/update-activity.yaml
+++ b/.github/workflows/update-activity.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   update-github-activity:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repo

--- a/get-data.py
+++ b/get-data.py
@@ -93,10 +93,14 @@ for query in queries:
         break
 
     with ProcessPoolExecutor(n_proc) as executor:
-        futures = [executor.submit(process_gh_results, page) for page in result]
+        try:
+            futures = [executor.submit(process_gh_results, page) for page in result]
 
-        for future in as_completed(futures):
-            all_items.extend(future.result())
+            for future in as_completed(futures):
+                all_items.extend(future.result())
+
+        except fastcore.basics.HTTP403ForbiddenError:
+            pass
 
 
 df = pd.DataFrame(all_items)


### PR DESCRIPTION
Catch 403 errors with a try/except block